### PR TITLE
Remove extra Meta.later_add arguments to fix a warning

### DIFF
--- a/src/gjs/mutter_window.ts
+++ b/src/gjs/mutter_window.ts
@@ -158,9 +158,7 @@ module MutterWindow {
 				function() {
 					// self.log.debug("Activating window " + self + " (" + reason + ")");
 					self._activate(time);
-				},
-				null, //data
-				null //notify
+				}
 			);
 		}
 		move_to_workspace(new_index) {

--- a/src/stub/shim.ts
+++ b/src/stub/shim.ts
@@ -1,3 +1,3 @@
-Lang = {
+var Lang: Lang = {
 	bind: function(subj, fn: Function) { return fn.bind(subj); },
 }


### PR DESCRIPTION
This removes the following runtime warning:
"Too many arguments to function Meta.later_add: expected 2, got 4"

It's hard to find good documentation for Meta but most other occurrences
in JavaScript projects I was able to find include just two arguments.